### PR TITLE
Centralize environment variable handling

### DIFF
--- a/hub2labhook/api/app.py
+++ b/hub2labhook/api/app.py
@@ -5,6 +5,10 @@ from flask import Flask, request
 from flask_cors import CORS
 
 
+from hub2labhook.config import (
+    APP_ENVIRON
+)
+
 def getvalues():
     jsonbody = request.get_json(force=True, silent=True)
     values = request.values.to_dict()
@@ -16,7 +20,7 @@ def getvalues():
 def create_app():
     app = Flask(__name__)
     CORS(app)
-    setting = os.getenv('APP_ENV', "development")
+    setting = APP_ENVIRON
     app.logger.addHandler(logging.StreamHandler(sys.stdout))
     app.logger.setLevel(logging.INFO)
     if setting != 'production':

--- a/hub2labhook/api/config.py
+++ b/hub2labhook/api/config.py
@@ -1,11 +1,16 @@
 import os
 
+from hub2labhook.config import (
+    GITLAB_SECRET_TOKEN,
+    GITLAB_API
+)
+
 
 class Config(object):
     """ Default configuration """
     DEBUG = True
-    GITLAB_TOKEN = os.getenv('GITLAB_TOKEN', "changeme")
-    GITLAB_API = os.getenv('GITLAB_API', "https://gitlab.com")
+    GITLAB_TOKEN = GITLAB_SECRET_TOKEN
+    GITLAB_API = GITLAB_API
 
 
 class ProductionConfig(Config):

--- a/hub2labhook/api/hook.py
+++ b/hub2labhook/api/hook.py
@@ -16,6 +16,13 @@ from hub2labhook.exception import (Hub2LabException,
 
 import hub2labhook.jobs.tasks as tasks
 
+from hub2labhook.config import (
+    GITHUB_SECRET_TOKEN,
+    BUILD_PULL_REQUEST,
+    BUILD_PUSH
+)
+
+
 hook_app = Blueprint('registry', __name__,)
 
 
@@ -53,7 +60,7 @@ def test_error():
 
 
 def verify_signature(payload_body, signature):
-    secret_token = os.getenv('GITHUB_SECRET_TOKEN', None)
+    secret_token = GITHUB_SECRET_TOKEN
     if secret_token is None:
         raise Unsupported("GITHUB_SECRET_TOKEN isn't configured, failed to verify signature")
     digest = 'sha1=' + hmac.new(secret_token, payload_body, hashlib.sha1).hexdigest()
@@ -69,10 +76,10 @@ def github_event():
     if hook_signature:
         verify_signature(request.data, hook_signature)
 
-    if os.getenv("BUILD_PULL_REQUEST", "true") == "true":
+    if BUILD_PULL_REQUEST == "true":
         allowed_events.append("pull_request")
 
-    if ((os.getenv("BUILD_PUSH", "false") == "true") or
+    if ((BUILD_PUSH == "true") or
         (event == "push" and
          (params['ref'] == "refs/heads/master" or str.startswith(params['ref'], "refs/tags/")))):
         allowed_events.append("push")

--- a/hub2labhook/config.py
+++ b/hub2labhook/config.py
@@ -1,0 +1,52 @@
+"""
+Acquire runtime configuration from environment variables (etc).
+"""
+
+import os
+
+
+def getenv(name, default=None, convert=str):
+    """
+    Fetch variables from environment and convert to given type.
+    
+    Python's `os.getenv` returns string and requires string default.
+    This allows for varying types to be interpolated from the environment.
+    """
+
+     # because os.getenv requires string default.
+    internal_default = "(none)"
+    val = os.getenv(name, internal_default)
+
+    if val == internal_default:
+        return default
+
+    if callable(convert):
+        return convert(val)
+
+    return val
+
+
+GITLAB_TIMEOUT = 30
+
+APP_ENVIRON = getenv("APP_ENV", "development")
+
+# Events from GitLab hooks will be authenticated with this token.
+GITLAB_SECRET_TOKEN_DEFAULT = "e19c1283c925b3206685ff522acfe3e6"
+GITLAB_SECRET_TOKEN = getenv("GITLAB_TOKEN", GITLAB_SECRET_TOKEN_DEFAULT)
+
+GITLAB_API = getenv("GITLAB_API", "https://gitlab.com")
+GITLAB_REPO = getenv("GITLAB_REPO", None)
+GITLAB_BRANCH = getenv("GITLAB_BRANCH", None)
+GITLAB_TRIGGER = getenv("GITLAB_TRIGGER", None)
+GITLAB_USER = getenv("GITLAB_USER", None)
+
+GITHUB_CONTEXT = getenv("GITHUB_CONTEXT", "gitlab-ci")
+GITHUB_INTEGRATION_ID = getenv("GITHUB_INTEGRATION_ID", "743")
+GITHUB_INSTALLATION_ID = getenv("GITHUB_INSTALLATION_ID", "3709")
+GITHUB_SECRET_TOKEN = getenv("GITHUB_SECRET_TOKEN", None)
+
+FAILFASTCI_NAMESPACE = getenv("FAILFASTCI_NAMESPACE", "failfast-ci")
+FAILFASTCI_API = getenv("FAILFAST_CI_API", "https://jobs.failfast-ci.io")
+
+BUILD_PULL_REQUEST = getenv("BUILD_PULL_REQUEST", "true")
+BUILD_PUSH = getenv("BUILD_PUSH", "false")

--- a/hub2labhook/github/client.py
+++ b/hub2labhook/github/client.py
@@ -5,13 +5,17 @@ import base64
 import jwt
 import requests
 import hub2labhook
-from hub2labhook.utils import getenv
 from hub2labhook.exception import ResourceNotFound
+
+from hub2labhook.config import (
+    GITHUB_INTEGRATION_ID,
+    GITHUB_INSTALLATION_ID
+)
 
 INTEGRATION_PEM = base64.b64decode(os.environ['GITHUB_INTEGRATION_PEM'])
 
-INTEGRATION_ID = int(os.getenv('GITHUB_INTEGRATION_ID', '743'))
-INSTALLATION_ID = '3709'
+INTEGRATION_ID = int(GITHUB_INTEGRATION_ID)
+INSTALLATION_ID = int(GITHUB_INSTALLATION_ID)
 STATUS_MAP = {
     "running": "pending",
     "failed": "failure",
@@ -24,7 +28,6 @@ STATUS_MAP = {
     "created": "pending",
     "running": "pending"
 }
-CONTEXT = os.getenv("GITHUB_CONTEXT", "gitlab-ci")
 
 
 def jwt_token():
@@ -43,7 +46,7 @@ def get_integration_pem():
 
 class GithubClient(object):
     def __init__(self, installation_id=None):
-        self.installation_id = getenv(installation_id, "GITHUB_INSTALLATION_ID", INSTALLATION_ID)
+        self.installation_id = installation_id or GITHUB_INSTALLATION_ID
         self.integration_pem = get_integration_pem()
         self._headers = None
         self._token = None

--- a/hub2labhook/options.py
+++ b/hub2labhook/options.py
@@ -1,3 +1,8 @@
+"""
+Runtime options derived from environment name
+"""
+
+
 import os
 from iziconf import Iziconf
 

--- a/hub2labhook/utils.py
+++ b/hub2labhook/utils.py
@@ -3,15 +3,6 @@ import time
 from threading import Thread
 
 
-def getenv(value, envname, default=None):
-    if not value:
-        if default:
-            value = os.getenv(envname, default)
-        else:
-            value = os.environ[envname]
-    return value
-
-
 class DelayedRequest(Thread):
     def __init__(self, delay, func):
         Thread.__init__(self)


### PR DESCRIPTION
To ensure consistent defaults and easily understand usage of environment vars, moving them into a single module.

This effort avoids breaking changes, however in this process, I noticed some conventions in specific environment variables which seem inconsistent. Perhaps we can evaluate reconciling these, which requires changing specific names of environment variables, in a subsequent release.