### PR TITLE
Configure GitLab project defaults via environ vars

### DIFF
--- a/hub2labhook/config.py
+++ b/hub2labhook/config.py
@@ -26,6 +26,10 @@ def getenv(name, default=None, convert=str):
     return val
 
 
+def envbool(value: str):
+    return value and (value.lower() in ('1', 'true'))
+
+
 GITLAB_TIMEOUT = 30
 
 APP_ENVIRON = getenv("APP_ENV", "development")
@@ -39,6 +43,27 @@ GITLAB_REPO = getenv("GITLAB_REPO", None)
 GITLAB_BRANCH = getenv("GITLAB_BRANCH", None)
 GITLAB_TRIGGER = getenv("GITLAB_TRIGGER", None)
 GITLAB_USER = getenv("GITLAB_USER", None)
+GITLAB_ENABLE_JOBS = True  # without this, CI is moot.
+
+GITLAB_ENABLE_SHARED_RUNNERS = getenv("GITLAB_SHARED_RUNNERS", 
+                                     default=False, convert=envbool)
+
+GITLAB_ENABLE_CONTAINER_REGISTRY = getenv("GITLAB_CONTAINER_REGISTRY",
+                                          default=False, convert=envbool)
+
+GITLAB_ENABLE_WIKI = getenv("GITLAB_WIKI", default=False, convert=envbool)
+GITLAB_ENABLE_SNIPPETS = getenv("GITLAB_SNIPPETS", default=False, 
+                                convert=envbool)
+
+
+GITLAB_ENABLE_MERGE_REQUESTS = getenv("GITLAB_MERGE_REQUESTS", default=False, 
+                                      convert=envbool)
+GITLAB_ENABLE_ISSUES = getenv("GITLAB_ISSUES", default=False, convert=envbool)
+
+GITLAB_REPO_PRIVACY = getenv("GITLAB_REPO_PRIVACY", default="internal")
+
+if GITLAB_REPO_PRIVACY not in ("private", "internal", "public"):
+    GITLAB_REPO_PRIVACY = "private"
 
 GITHUB_CONTEXT = getenv("GITHUB_CONTEXT", "gitlab-ci")
 GITHUB_INTEGRATION_ID = getenv("GITHUB_INTEGRATION_ID", "743")

--- a/hub2labhook/gitlab/client.py
+++ b/hub2labhook/gitlab/client.py
@@ -7,14 +7,31 @@ import requests
 
 import hub2labhook
 
-from hub2labhook.config import (GITLAB_SECRET_TOKEN, GITLAB_TIMEOUT, GITLAB_API, GITLAB_REPO,
-                                GITLAB_BRANCH, GITLAB_TRIGGER, FAILFASTCI_NAMESPACE)
+
+from hub2labhook.config import (
+    GITLAB_SECRET_TOKEN,
+    GITLAB_TIMEOUT, 
+    GITLAB_API,
+    GITLAB_REPO,
+    GITLAB_BRANCH,
+    GITLAB_TRIGGER,
+    GITLAB_ENABLE_SHARED_RUNNERS,
+    GITLAB_ENABLE_CONTAINER_REGISTRY,
+    GITLAB_ENABLE_WIKI,
+    GITLAB_ENABLE_SNIPPETS,
+    GITLAB_ENABLE_MERGE_REQUESTS,
+    GITLAB_ENABLE_ISSUES,
+    GITLAB_ENABLE_JOBS,
+    GITLAB_REPO_PRIVACY,
+    FAILFASTCI_NAMESPACE,
+    FAILFASTCI_API
+)
 
 API_VERSION = "/api/v4"
 
 
 class GitlabClient(object):
-    def __init__(self, endpoint: str = None, token: str = None):
+    def __init__(self, endpoint: str=None, token: str=None):
         """
         Creates a gitlab-client instance initialized with the private-token and endpoint urllib
 
@@ -121,7 +138,7 @@ class GitlabClient(object):
         resp.raise_for_status()
         return resp.json()[0]['id']
 
-    def get_or_create_project(self, project_name, namespace=None):
+    def get_or_create_project(self, project_name, namespace=None, repo_public: bool=False):
         group_name = namespace or FAILFASTCI_NAMESPACE
         project_path = "%s%%2f%s" % (group_name, project_name)
         path = self._url("/projects/%s" % (project_path))
@@ -133,16 +150,16 @@ class GitlabClient(object):
         body = {
             "name": project_name,
             "namespace_id": group_id,
-            "issues_enabled": False,
-            "merge_requests_enabled": False,
-            "jobs_enabled": True,
-            "wiki_enabled": False,
-            "snippets_enabled": False,
-            "container_registry_enabled": False,
-            "shared_runners_enabled": False,
-            "public": True,
-            "visibility_level": 20,
-            "public_jobs": True,
+            "issues_enabled": GITLAB_ENABLE_ISSUES,
+            "merge_requests_enabled": GITLAB_ENABLE_MERGE_REQUESTS,
+            "jobs_enabled": GITLAB_ENABLE_JOBS, 
+            "wiki_enabled": GITLAB_ENABLE_WIKI,
+            "snippets_enabled": GITLAB_ENABLE_SNIPPETS,
+            "container_registry_enabled": GITLAB_ENABLE_CONTAINER_REGISTRY,
+            "shared_runners_enabled": GITLAB_ENABLE_SHARED_RUNNERS, 
+            "public": repo_public,
+            "visibility": ("public" if repo_public else GITLAB_REPO_PRIVACY),
+            "public_jobs": repo_public, 
         }
         resp = requests.post(path, data=json.dumps(body), headers=self.headers,
                              timeout=GITLAB_TIMEOUT)
@@ -180,7 +197,7 @@ class GitlabClient(object):
         resp.raise_for_status()
         return resp.json()
 
-    def initialize_project(self, project_name: str, namespace: str = None):
+    def initialize_project(self, project_name: str, namespace: str=None):
         project = self.get_or_create_project(project_name, namespace)
         branch = "master"
         branch_path = self._url("/projects/%s/repository/branches/%s" % (project['id'], branch))

--- a/hub2labhook/pipeline.py
+++ b/hub2labhook/pipeline.py
@@ -156,7 +156,7 @@ class Pipeline(object):
             'PR_ID': str(gevent.pr_id),
             'SHA': gevent.head_sha,
             'SHA8': gevent.head_sha[0:8],
-            'FAILFASTCI_STATUS_API': "https://jobs.failfast-ci.io/api/v1/github_status",
+            'FAILFASTCI_STATUS_API': ('%s/api/v1/github_status' % (FAILFASTCI_API,)),
             'SOURCE_REF': gevent.refname,
             'REF_NAME': gevent.refname,
             'CI_REF': gevent.target_refname,


### PR DESCRIPTION
The following settings for each *newly created* GitLab project are now defined
based on environment variables:

- Use of shared runners; disabled by default.
- Default project privacy; set "internal" by default, "private" if invalid.
- Activation of GitLab Wiki; disabled by default.
- Activation of GitLab Snippets; disabled by default.
- Activation of GitLab's merge requests features; disabled by default.
- Activation of GitLab's issues; disabled by default.

A few small additions to support *future* adoption of GitHub's project privacy
setting for each new project. A couple other points that *should* have been
configured from environment variables also are now (fixed).