### PR TITLE
Revert "replace double__underscore"

### DIFF
--- a/hub2labhook/pipeline.py
+++ b/hub2labhook/pipeline.py
@@ -144,7 +144,7 @@ class Pipeline(object):
         gitlab_endpoint = content['variables'].get('GITLAB_URL', None)
         self.gitlab = GitlabClient(gitlab_endpoint)
 
-        ci_project = self.gitlab.initialize_project(gevent.repo.replace("/", "."), namespace)
+        ci_project = self.gitlab.initialize_project(gevent.repo.replace("/", "__"), namespace)
 
         # @Todo(ant31) check if clone_url is required
         # clone_url = clone_url_with_auth(gevent.clone_url, "bot:%s" % self.github.token)


### PR DESCRIPTION
Reverts failfast-ci/failfast-api#28

GitLab, though it allows dots in project names and project urls, alters the project url during the creation process causing git_or_create to think it needs created but then it fails because it already exists. Reverting to come up with a different approach.