### PR TITLE
GitLab still changes the path

### DIFF
--- a/hub2labhook/gitlab/client.py
+++ b/hub2labhook/gitlab/client.py
@@ -143,7 +143,6 @@ class GitlabClient(object):
         path = self._url("/projects")
         body = {
             "name": project_name,
-            "path": project_path,
             "namespace_id": group_id,
             "issues_enabled": GITLAB_ENABLE_ISSUES,
             "merge_requests_enabled": GITLAB_ENABLE_MERGE_REQUESTS,

--- a/hub2labhook/pipeline.py
+++ b/hub2labhook/pipeline.py
@@ -154,7 +154,7 @@ class Pipeline(object):
         self.gitlab = GitlabClient(gitlab_endpoint)
 
         ci_project = self.gitlab.initialize_project(
-            gevent.repo.replace("/", "."), namespace)
+            gevent.repo.replace("/", "_"), namespace)
 
         # @Todo(ant31) check if clone_url is required
         # clone_url = clone_url_with_auth(gevent.clone_url, "bot:%s" % self.github.token)


### PR DESCRIPTION
Even if the path is explicitly sent with the data packet, GitLab still
modifies it for no reason.

I've removed the optional, "path" I added and replaced the dot with a
single underscore. GitLab has made changes that will appear in 10.3 to
allow the double underscore again. We may come back to this at that
time.