### PR TITLE
Status update job's runner tag can be overridden

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,4 @@ target/
 # Development environment
 .virtenv
 .vscode/
+*.orig

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ clean-test:
 	rm -fr htmlcov/
 
 
-.virtenv/.date: requirements_dev.txt requirements_test.txt
+.virtenv/.date: requirements_dev.txt requirements_test.txt requirements.txt
 	virtualenv -p python3.6 $(shell dirname $@)
 	. $(shell dirname $@)/bin/activate && for f in $<; do pip install -r $$f; done && pip install -e .
 	touch -r $< $@

--- a/hub2labhook/config.py
+++ b/hub2labhook/config.py
@@ -93,6 +93,12 @@ GITHUB_SECRET_TOKEN = getenv("GITHUB_SECRET_TOKEN", None)
 FAILFASTCI_NAMESPACE = getenv("FAILFASTCI_NAMESPACE", "failfast-ci")
 FAILFASTCI_API = getenv("FAILFAST_CI_API", "https://jobs.failfast-ci.io")
 
+# The GitLab runner tag to require on CI jobs introduced by failfast
+FAILFASTCI_REQUIRE_RUNNER_TAG = getenv("FAILFASTCI_RUNNER_TAG", "failfast-ci")
+
+if FAILFASTCI_REQUIRE_RUNNER_TAG.lower() in ('none', ):
+    FAILFASTCI_REQUIRE_RUNNER_TAG = None
+
 BUILD_PULL_REQUEST = getenv("BUILD_PULL_REQUEST", "true")
 BUILD_PUSH = getenv("BUILD_PUSH", "false")
 

--- a/hub2labhook/pipeline.py
+++ b/hub2labhook/pipeline.py
@@ -13,7 +13,8 @@ from hub2labhook.github.client import GithubClient
 from hub2labhook.gitlab.client import GitlabClient
 from hub2labhook.exception import Unexpected, ResourceNotFound
 from hub2labhook.utils import clone_url_with_auth
-from hub2labhook.config import (GITLAB_USER, FAILFASTCI_API)
+from hub2labhook.config import (
+    GITLAB_USER, FAILFASTCI_API, FAILFASTCI_REQUIRE_RUNNER_TAG)
 
 from git import Repo
 
@@ -115,10 +116,14 @@ class Pipeline(object):
                 "echo curl -XPOST %s -d \"%s\" || true" %
                 (url, params_150.replace('"', '\\\"'))
             ],
-            "tags": ["failfast-ci"],
             "when":
                 "always"
         }
+
+        if isinstance(FAILFASTCI_REQUIRE_RUNNER_TAG, str) and \
+                bool(FAILFASTCI_REQUIRE_RUNNER_TAG):
+            job['tags'] = [FAILFASTCI_REQUIRE_RUNNER_TAG]
+
         content['stages'].append(stage_name)
         content['report-status'] = job
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,14 @@
+futures
+celery[redis]
+iziconf
+requests
+flask
+Flask>=0.10.1
+flask-cors
+PyJWT
+PyYaml
+gitpython
+cryptography
+celery
+flower
+jaeger-client


### PR DESCRIPTION
Until now, the status update job requires the tag `failfast-ci` on runners to deliver the status update to GitHub PRs. This update retains that as the default behavior, but allows environment to override.

If any case-variant of `none` is provided, it will *remove* the tag requirement from the status update job.

This is a *temporary* solution to a current operational problem, and will no longer be necessary when the status-update job is deprecated, in favor of using GitLab hooks.