### PR TITLE
Allow authorizing prs, labels, and comments based on user and group info

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,12 @@ ENV workdir=/opt/failfast-ci
 RUN apk --no-cache --update add openssl ca-certificates
 RUN apk --no-cache add --virtual build-dependencies \
     libffi-dev build-base openssl-dev bash git
-RUN pip install pip -U
+RUN pip install -U 'pip>=9.0' && pip install 'setuptools>=20.8.1'
 RUN rm -rf $workdir
 RUN mkdir -p $workdir
 COPY . $workdir
 WORKDIR $workdir
-RUN pip install gunicorn gevent -U && pip install -e .
+RUN pip install gunicorn gevent -U
+RUN pip install -e .
 
 CMD ["./run-server.sh"]

--- a/Documentation/config/failfast-ci.yaml
+++ b/Documentation/config/failfast-ci.yaml
@@ -1,11 +1,15 @@
 failfast:
-  authorized_groups: [COLLABORATOR, MEMBER, OWNER]
-  authorized_users: []
-  build:
-    on-branches: [master]
-    on-comments: [/retest, /test]
-    on-labels: [ok-to-test]
-    on-pullrequests: ['*']
+  triggers:
+    branches:
+      trigger-on: [master]
+    comments:
+      trigger-on: [/retest, /test]
+      groups: [COLLABORATOR, MEMBER, OWNER] 
+    labels:
+      trigger-on: [ok-to-test]
+    pullrequests:
+      trigger-on: ['*']
+      groups: [COLLABORATOR, MEMBER, OWNER]  
   debug: false
   env: development
   failfast_url: https://jobs.failfast-ci.com

--- a/hub2labhook/config.py
+++ b/hub2labhook/config.py
@@ -120,19 +120,22 @@ class FailFastConfig(object):
                 'debug': False,
                 'env': APP_ENVIRON,
                 'failfast_url': FAILFASTCI_API,
-                'build': {
-                    'on-pullrequests': ['*'],
-                    'on-branches': ['master'],
-                    'on-labels': [
-                        'ok-to-test'
-                    ],  # list branches (regexp) to trigger builds on push events
-                    'on-comments': [
-                        '/retest', '/test'
-                    ],  # list branches (regexp) to trigger builds on PR events
-                },
-                # https://developer.github.com/v4/reference/enum/commentauthorassociation/
-                'authorized_groups': ['COLLABORATOR', 'MEMBER', 'OWNER'],
-                'authorized_users': [],
+                'triggers': {
+                    'branches': {
+                        'trigger-on': ['master'],
+                    },
+                    'comments': {
+                        'trigger-on': ['/retest', '/test'],
+                        'groups': ['COLLABORATOR', 'MEMBER', 'OWNER'],
+                    },
+                    'labels': {
+                        'trigger-on': ['ok-to-test'],  
+                    },
+                    'pullrequests': {
+                        'trigger-on': ['*'],
+                        'groups': ['COLLABORATOR', 'MEMBER', 'OWNER'],
+                    },  
+                }, 
             },
             'github': {
                 'context': GITHUB_CONTEXT,

--- a/hub2labhook/github/models/event.py
+++ b/hub2labhook/github/models/event.py
@@ -92,7 +92,13 @@ class GithubEvent(object):
 
     @property
     def author_association(self):
-        return self.event['issue']['comment']['author_association']
+        if self.event_type == "issue_comment":
+            return self.event['issue']['comment']['author_association']
+        elif self.event_type == "pull_request":
+            return self.event['pull_request']['author_associateion']
+        else:
+            self._raise_unsupported()
+        return None
 
     @property
     def action(self):

--- a/hub2labhook/github/models/event.py
+++ b/hub2labhook/github/models/event.py
@@ -13,6 +13,8 @@ class GithubEvent(object):
             ref = self.event['ref']
         elif self.event_type == "pull_request":
             ref = self.event['pull_request']['head']['ref']
+        elif self.event_type == "pull_request_review_comment":
+            ref = self.event['pull_request']['head']['ref']
         else:
             self._raise_unsupported()
         return ref
@@ -61,7 +63,7 @@ class GithubEvent(object):
 
     @property
     def refname(self):
-        if self.event_type not in ["push", "pull_request"]:
+        if self.event_type not in ["push", "pull_request", "pull_request_review_comment"]:
             self._raise_unsupported()
 
         if not self._refname:
@@ -74,6 +76,8 @@ class GithubEvent(object):
         if self.event_type == "push":
             return self.ref
         elif self.event_type == "pull_request":
+            return "pr-%s-%s" % (self.pr_id, self.refname)
+        elif self.event_type == "pull_request_review_comment":
             return "pr-%s-%s" % (self.pr_id, self.refname)
         else:
             self._raise_unsupported()
@@ -95,8 +99,9 @@ class GithubEvent(object):
         if self.event_type == "issue_comment":
             return self.event['issue']['comment']['author_association']
         elif self.event_type == "pull_request":
-            return self.event['pull_request']['author_associateion']
-        else:
+            return self.event['pull_request']['author_association']
+        elif self.event_type == "pull_request_review_comment":
+            return self.event['pull_request']['author_association']
             self._raise_unsupported()
         return None
 
@@ -120,6 +125,8 @@ class GithubEvent(object):
             sha = self.event['head_commit']['id']
         elif self.event_type == "pull_request":
             sha = self.event['pull_request']['head']['sha']
+        elif self.event_type == "pull_request_review_comment":
+            sha = self.event['pull_request']['head']['sha']
         else:
             self._raise_unsupported()
         return sha
@@ -131,14 +138,14 @@ class GithubEvent(object):
 
     @property
     def repo(self):
-        if self.event_type not in ["push", "pull_request"]:
+        if self.event_type not in ["push", "pull_request", "pull_request_review_comment"]:
             self._raise_unsupported()
 
         return self.event['repository']['full_name']
 
     @property
     def pr_repo(self):
-        if self.event_type not in ["pull_request"]:
+        if self.event_type not in ["pull_request", "pull_request_review_comment"]:
             self._raise_unsupported()
         return self.event['pull_request']['head']['repo']['full_name']
 
@@ -147,6 +154,8 @@ class GithubEvent(object):
         if self.event_type == "push":
             user = self.event['pusher']['name']
         elif self.event_type == "pull_request":
+            user = self.event['pull_request']['user']['login']
+        elif self.event_type == "pull_request_review_comment":
             user = self.event['pull_request']['user']['login']
         elif self.event_type == "issue_comment":
             user = self.event['issue']['comment']['user']['login']

--- a/hub2labhook/github/models/event.py
+++ b/hub2labhook/github/models/event.py
@@ -102,6 +102,7 @@ class GithubEvent(object):
             return self.event['pull_request']['author_association']
         elif self.event_type == "pull_request_review_comment":
             return self.event['pull_request']['author_association']
+        else:
             self._raise_unsupported()
         return None
 

--- a/hub2labhook/jobs/tasks.py
+++ b/hub2labhook/jobs/tasks.py
@@ -213,7 +213,9 @@ def start_pipeline(event, headers):
     trigger_build = (
         istriggered_on_branches(gevent, config) or
         istriggered_on_pr(gevent, config) or
-        istriggered_on_labels(gevent, config))
+        istriggered_on_labels(gevent, config) or 
+        istriggered_on_comments(gevent, config)
+    )
     if trigger_build:
         task = pipeline.s(event, headers)
         status_sig = signature('hub2labhook.jobs.tasks.update_github_statuses',

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ futures
 celery[redis]
 iziconf
 requests
-flask
 Flask>=0.10.1
 flask-cors
 PyJWT
@@ -11,4 +10,3 @@ gitpython
 cryptography
 celery
 flower
-jaeger-client

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,6 @@ requirements = [
     'celery',
     'flower',
     'mypy',
-    'jaeger-client'
 ]
 
 test_requirements = [


### PR DESCRIPTION
This adds authorization support for PRs, labels, and comments.

I noticed that `issue_comment` isn't wired up as a supported event, so I added that as well (though it will currently do nothing since it needs another api call to get the repo info).

I added support for `pull_request_review_comment` event types, which have the same context as pull requests and so can be authorized without another api call.

I was also having issues with the docker build due to some problems with pip and some dependencies, but it looks like those dependencies weren't used anywhere so I removed them