### PR TITLE
Add error information in GitHub error

### DIFF
--- a/hub2labhook/jobs/tasks.py
+++ b/hub2labhook/jobs/tasks.py
@@ -106,7 +106,8 @@ def update_github_statuses_failure(self, request, exc, traceback, event,
     body = dict(
         state=GITHUB_STATUS_MAP["canceled"],
         target_url=(gevent.commit_url),  # TODO: link the gitlab YAML
-        description="An error occurred in initial pipeline execution",
+        description="An error occurred in pipeline execution. %s: %s" % (exc,
+            exc.message),
         context="%s/%s" % (FFCONFIG.github['context'], "pipeline"))
     return githubclient.post_status(body, gevent.repo, gevent.head_sha)
 


### PR DESCRIPTION
In Kubespray i ran into the `An error occurred in pipeline execution` a couple of times. It's difficult to troubleshoot without further information about the error (like the exception name and message), therefore I suggest to add that to the error output.