### PR TITLE
Use the new access_token endpoint

### DIFF
--- a/hub2labhook/github/client.py
+++ b/hub2labhook/github/client.py
@@ -113,7 +113,7 @@ class GithubClient(object):
                                             self.integration_pem)
             }
             path = self._url(
-                "/installations/%s/access_tokens" % self.installation_id)
+                "/app/installations/%s/access_tokens" % self.installation_id)
 
             resp = requests.post(path, headers=headers)
             resp.raise_for_status()


### PR DESCRIPTION
The `installations/:installation_id/access_tokens` route will unavailable from October 1st. It has been replaced by `app/installations/:installation_id/access_tokens`.


See https://developer.github.com/changes/2018-08-16-renaming-and-deprecation-of-github-app-installation-access-token-route/ and https://developer.github.com/changes/2020-04-15-replacing-create-installation-access-token-endpoint/